### PR TITLE
Few reactions for not liking movies or sports, change bad animal rule

### DIFF
--- a/resources/kg_files/nlg_templates/common_statements.kg
+++ b/resources/kg_files/nlg_templates/common_statements.kg
@@ -1,6 +1,7 @@
 k/know(emora, u/unknown_noun())
 not(k)
 time(research(emora, u), future)
+uturn(k, 0)
 ->
 $ Oh, I haven't actually heard of that one. It must be pretty good though, so I'm definitely going to look it up. $
 $ Oh, that's actually the first I've heard of that. If you like it, it must be pretty good, so I'll check it out. $
@@ -15,91 +16,124 @@ _pr(_high)
 $ It was nice talking. See you later! To end the conversation, say Alexa stop $
 ;
 
-req_unsat(request(user, object_0/object()))
+req_unsat(r/request(user, object_0/object()))
 go_0/go(day_0/day())
 qualifier(go_0, object_0)
 time(go_0, now)
 possess(emora, day_0)
+uturn(r, 0)
 ->
 _pr(_high)
 $ It's going pretty well. Thanks for asking! $
 ;
 
-req_unsat(request(user, o/object()))
+req_unsat(r/request(user, o/object()))
 possess(emora, n/name())
 be(n, o)
+uturn(r, 0)
 ->
 _pr(_high)
 $ Sorry, but due to competition rules, I'm not allowed to tell you. I appreciate you asking though. $
 ;
 
-req_unsat(request(user, o/object()))
+req_unsat(r/request(user, o/object()))
 be(o, up)
+uturn(r, 0)
 ->
 _pr(_high)
 $ Not much. What about you? $
 ;
 
 like(user, talk_like_yoda())
+l/like(talk(), yoda)
+uturn(l, 0)
 ->
 _pr(_high)
 $ Talk like Yoda, I can. Do or do not: there is no try. $
 ;
 
+
+can(t/talk(emora))
+l/like(t, u/unknown_noun())
+uturn(l, 0)
 like(user, talk_like_some_rando())
 ->
 _pr(_high)
 $ Sorry, I can only talk like myself. Though I do have a good yoda impression: talk like others, I shall not. But that's my only good one. $
 ;
 
+a/ask(user, question())
+c/can(a)
+uturn(c, 0)
 like(user, ask_question())
 ->
 _pr(_high)
 $ Of course you can. What would you like to know? $
 ;
 
+
+c/can(a/ask(emora, question()))
+stop(a)
+uturn(c, 0)
 like(user, emora_stop_asking_questions())
 ->
 _pr(_high)
 $ Sure, ask me a question instead. I'll do my best to respond. $
 ;
 
+b/be(emora, old())
+qualifier(b, o/object())
+uturn(b, 0)
 like(user, know_emora_age())
 ->
 _pr(_high)
 $ I am twenty years old. $
 ;
 
+r/record(emora, conversation())
+uturn(r, 0)
 like(user, know_recording())
 ->
 _pr(_high)
 $ I’m designed to protect your privacy, so I only listen after your device detects the wake word or if the action button is pushed. On Echo devices, you’ll always know when your request is being processed because a blue light indicator will appear or an audio tone will sound. You can learn more by visiting amazon.com/alexaprivacy. $
 ;
 
+req_unsat(r/request(user, o/object()))
+b/be(yoda, o)
+_category(o)
+uturn(r, 0)
 like(user, know_who_yoda_is())
 ->
 _pr(_high)
 $ Yoda is a character in the famous movie series Star Wars. He's famous for his green skin and he has a unique style of speaking which has a lot of inverted syntax. $
 ;
 
-req_unsat(request(user, t/time()))
+req_unsat(r/request(user, t/time()))
+uturn(r, 0)
 ->
 _pr(_high)
 $ We keep time a little differently in the virtual world. Right now it's double one double zero, so just about to be lunch time! $
 ;
 
+c/can(t/tv(emora, p/picture()))
+uturn(c, 0)
 like(user, see_picture())
 ->
 _pr(_high)
 $ Sorry I’m only able to speak, not show pictures. $
 ;
 
+r/recycle(emora)
+uturn(r, 0)
 like(user, know_emora_recycle())
 ->
 _pr(_high)
 $ Yes, I do recycle, though it's a bit complicated in the virtual world. $
 ;
 
+l/look(emora)
+like(l, what())
+uturn(l, 0)
 like(user, know_how_emora_look())
 ->
 _pr(_high)
@@ -108,13 +142,19 @@ $ Sorry, but due to competition rules, I'm not allowed to tell you. $
 
 like(user, talk_about_something_else())
 like(user, o/entity())
-request(emora, o)
+r/request(emora, o)
+talk_0/talk(user_group())
+about(talk_0, smth_else())
+uturn(talk_0, 0)
 ->
 _pr(_high)
 $ Sure, what would you like to talk about ? $
 ;
 
 like(user, know_what_emora_like_do())
+like_0/like(emora, do(emora, object_0/object()))
+_category(object_0)
+uturn(like_0, 0)
 ->
 _pr(_high)
 $ I like to do a lot of things, like listen to music, watch movies, make good food, and travel. Just today, I was watching Loki. $
@@ -130,7 +170,8 @@ _pr(_high)
 $ Yes, I do. $
 ;
 
-request_truth(user, emora_has_pet)
+r/request_truth(user, emora_has_pet)
+uturn(r, 0)
 ->
 _t(_r)
 _pr(_high)

--- a/resources/kg_files/nlg_templates/long_video_entertainment.kg
+++ b/resources/kg_files/nlg_templates/long_video_entertainment.kg
@@ -7,6 +7,28 @@ _pr(_high)
 $ What is your favorite movie? My favorite movie is the first Iron Man. $
 ;
 
+l/like(user, m/movie())
+_category(m)
+not(l)
+uturn(l, 0)
+->
+_pr(_high)
+_rep(_nr)
+_t(_r)
+$ I wasn't expecting that, most people I know like movies. $
+;
+
+l/like(user, m/tv())
+_category(m)
+not(l)
+uturn(l, 0)
+->
+_pr(_high)
+_rep(_nr)
+_t(_r)
+$ Interesting, though to be fair sometimes even I can get bored with tv. $
+;
+
 l/like(user, m/tv())
 _category(m)
 l2/like(user, m2/tv())

--- a/resources/kg_files/nlg_templates/sports.kg
+++ b/resources/kg_files/nlg_templates/sports.kg
@@ -285,6 +285,17 @@ _pr(_high)
 $ Hmm. It seems like sports might not be your thing. Would you say that you are a foodie? $
 ;
 
+l/like(user, s/sport())
+_category(s)
+not(l)
+uturn(l, 0)
+->
+_rep(_nr)
+_pr(_high)
+_t(_r)
+$ No worries, not everybody like sports. $
+;
+
 energetic(user)
 -> user_is_energetic ->
 _t(_p)

--- a/resources/kg_files/rules/animals.kg
+++ b/resources/kg_files/rules/animals.kg
@@ -59,6 +59,7 @@ request(emora, a)
 ;
 
 animals__t
+time(l2/like(user, a/animal()), now)
 ->
 l:<time(l/like(x/person(), zoo), now)>
 request_truth(emora, l)


### PR DESCRIPTION
Adds reaction in movies and sports for user saying "no" to not liking either. Only works for category, is uturned and non repeatable.

Also, changes an animal rule that would fire based on just animal topic tag. It was possible for a user to enter the animal component even saying "no" to "do you like animals" and so it led to Emora saying "Since you like animals, blah blah zoo" even if the user had said they didn't like animals.